### PR TITLE
expose curl dep API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,5 +319,10 @@ pub mod error;
 pub mod http_client;
 pub mod request;
 pub mod response;
+
+pub mod dep {
+    pub use curl;
+}
+
 #[cfg(test)]
 mod test;


### PR DESCRIPTION
Closes #23

could be published as 0.3.1, but if you would rather not, also ok for me