### PR TITLE
allow bare send_request

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, time::Duration};
 
 use async_curl::actor::CurlActor;
-use curl::easy::{Auth, Easy, Easy2, Handler, ProxyType, TimeCondition};
+use curl::easy::{Auth, Easy2, Handler, ProxyType, TimeCondition};
 use derive_deref_rs::Deref;
 use http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, Method, StatusCode};
 use log::trace;


### PR DESCRIPTION
This is the first PR in this repo I'm not 100% certain you'll like the direction or not.

Gist is that we now allow custom handler, but that at the moment it wasn't useful as one cannot get to it after the perform is done. On top of that I do not really need a lot of the work done by that perform and instead would be fine just having the bear Easy2 API at that point. So this PR is to combine these 2 desires.

However, feel free to make a counter proposal. Just know that something will needed to be done to make a custom Collector useful at all, as for now the only other option would be to do unsafe stuff or put it behind a lock if one wants to somehow get access to it from multiple locations.