### PR TITLE
feat: support both sync and async curl transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "async-curl"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8288a2eaea9454b8a65157dd90541094843ca1f0c054369d66c02ba7ef084d2"
+checksum = "309e36dcc351618ca5dbc27cab7f1ab80bb2ca911f6853669d6e8e1a18061361"
 dependencies = [
  "curl",
  "log",
@@ -72,7 +72,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -146,9 +146,9 @@ checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "curl"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e5123ab8c31200ce725939049ecd4a090b242608f24048131dedf9dd195aed"
+checksum = "1e2161dd6eba090ff1594084e95fd67aeccf04382ffea77999ea94ed42ec67b6"
 dependencies = [
  "curl-sys",
  "libc",
@@ -161,7 +161,7 @@ dependencies = [
 
 [[package]]
 name = "curl-http-client"
-version = "0.4.3"
+version = "1.0.0"
 dependencies = [
  "async-curl",
  "curl",
@@ -345,7 +345,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -428,9 +428,9 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "http"
@@ -523,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -677,9 +677,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
@@ -832,7 +832,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -940,7 +940,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -951,28 +951,28 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
  "test-case-core",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1014,7 +1014,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "curl-http-client"
-version = "0.4.3"
+version = "1.0.0"
 edition = "2021"
 authors = ["Lorenzo Leonardo <enzotechcomputersolutions@gmail.com>"]
 license = "MIT"
-description = "This is a wrapper for Easy2 from curl-rust crate for ergonomic use and is able to perform asynchronously using async-curl crate that uses an actor model (Message passing) to achieve a non-blocking I/O."
+description = "This is a wrapper for Easy2 from curl-rust crate for ergonomic use and is able to perform synchronously and asynchronously using async-curl crate that uses an actor model (Message passing) to achieve a non-blocking I/O."
 repository = "https://github.com/LorenzoLeonardo/curl-http-client"
 homepage = "https://github.com/LorenzoLeonardo/curl-http-client"
 documentation = "https://docs.rs/curl-http-client"

--- a/examples/asynchronous.rs
+++ b/examples/asynchronous.rs
@@ -12,7 +12,7 @@ async fn main() {
     let mut handles = Vec::new();
 
     for _n in 0..NUM_CONCURRENT {
-        let curl = curl.clone();
+        let actor = curl.clone();
 
         let handle = tokio::spawn(async move {
             let collector = Collector::Ram(Vec::new());
@@ -23,9 +23,10 @@ async fn main() {
                 body: None,
             };
 
-            let response = HttpClient::new(curl, collector)
+            let response = HttpClient::new(collector)
                 .request(request)
                 .unwrap()
+                .nonblocking(actor)
                 .perform()
                 .await
                 .unwrap();

--- a/examples/download.rs
+++ b/examples/download.rs
@@ -11,7 +11,7 @@ use url::Url;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
 
     let collector = Collector::File(FileInfo::path(PathBuf::from("<FILE PATH TO SAVE>")));
 
@@ -22,9 +22,10 @@ async fn main() {
         body: None,
     };
 
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();

--- a/examples/get.rs
+++ b/examples/get.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
     let collector = Collector::Ram(Vec::new());
 
     let request = HttpRequest {
@@ -15,9 +15,10 @@ async fn main() {
         body: None,
     };
 
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();

--- a/examples/post.rs
+++ b/examples/post.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
     let collector = Collector::Ram(Vec::new());
 
     let request = HttpRequest {
@@ -15,9 +15,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         body: Some("test body".as_bytes().to_vec()),
     };
 
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();

--- a/examples/resume_download.rs
+++ b/examples/resume_download.rs
@@ -12,7 +12,7 @@ use url::Url;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
     let save_to = PathBuf::from("<FILE PATH TO SAVE>");
     let collector = Collector::File(FileInfo::path(save_to.clone()));
 
@@ -24,11 +24,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         body: None,
     };
 
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .resume_from(BytesOffset::from(partial_download_file_size))
         .unwrap()
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();

--- a/examples/upload.rs
+++ b/examples/upload.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let file_to_be_uploaded = PathBuf::from("<FILE PATH TO BE UPLOADED>");
     let file_size = fs::metadata(file_to_be_uploaded.as_path()).unwrap().len() as usize;
 
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
     let collector = Collector::File(FileInfo::path(file_to_be_uploaded));
 
     let request = HttpRequest {
@@ -24,11 +24,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         body: None,
     };
 
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .upload_file_size(FileSize::from(file_size))
         .unwrap()
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();

--- a/src/test/asynchronous.rs
+++ b/src/test/asynchronous.rs
@@ -30,9 +30,10 @@ async fn test_across_multiple_threads() {
         let collector = collector.clone();
         let request = request.clone();
         let handle = tokio::spawn(async move {
-            let response = HttpClient::new(curl, collector)
+            let response = HttpClient::new(collector)
                 .request(request)
                 .unwrap()
+                .nonblocking(curl)
                 .perform()
                 .await
                 .unwrap();

--- a/src/test/download.rs
+++ b/src/test/download.rs
@@ -18,7 +18,7 @@ async fn test_download() {
     let target_url = Url::parse(format!("{}/test", server.uri()).as_str()).unwrap();
 
     let save_to = tempdir.path().join("downloaded_file.jpg");
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
     let collector = Collector::File(FileInfo::path(save_to.clone()));
     let request = HttpRequest {
         url: target_url,
@@ -26,9 +26,10 @@ async fn test_download() {
         headers: HeaderMap::new(),
         body: None,
     };
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();
@@ -47,7 +48,7 @@ async fn test_download_with_speed_control() {
     let target_url = Url::parse(format!("{}/test", server.uri()).as_str()).unwrap();
 
     let save_to = tempdir.path().join("downloaded_file.jpg");
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
     let collector = Collector::File(FileInfo::path(save_to.clone()));
     let request = HttpRequest {
         url: target_url,
@@ -55,11 +56,12 @@ async fn test_download_with_speed_control() {
         headers: HeaderMap::new(),
         body: None,
     };
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .download_speed(BytesPerSec::from(40000000))
         .unwrap()
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();
@@ -87,7 +89,7 @@ async fn test_resume_download(offset: usize, expected_status_code: StatusCode) {
 
     let partial_file_size = fs::metadata(save_to.as_path()).unwrap().len() as usize;
 
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
     let collector = Collector::File(FileInfo::path(save_to.clone()));
     let request = HttpRequest {
         url: target_url,
@@ -95,11 +97,12 @@ async fn test_resume_download(offset: usize, expected_status_code: StatusCode) {
         headers: HeaderMap::new(),
         body: None,
     };
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .resume_from(BytesOffset::from(partial_file_size))
         .unwrap()
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();
@@ -119,7 +122,7 @@ async fn test_download_with_transfer_speed_sender() {
 
     let save_to = tempdir.path().join("downloaded_file.jpg");
 
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
 
     let (tx, mut rx) = channel(1);
 
@@ -138,11 +141,12 @@ async fn test_download_with_transfer_speed_sender() {
         }
     });
 
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .download_speed(BytesPerSec::from(40000000))
         .unwrap()
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();
@@ -163,7 +167,7 @@ async fn test_download_with_headers() {
     let target_url = Url::parse(format!("{}/test", server.uri()).as_str()).unwrap();
 
     let save_to = tempdir.path().join("downloaded_file.jpg");
-    let curl = CurlActor::new();
+    let actor = CurlActor::new();
     let collector = Collector::FileAndHeaders(FileInfo::path(save_to.clone()), Vec::new());
     let request = HttpRequest {
         url: target_url,
@@ -171,9 +175,10 @@ async fn test_download_with_headers() {
         headers: HeaderMap::new(),
         body: None,
     };
-    let response = HttpClient::new(curl, collector)
+    let response = HttpClient::new(collector)
         .request(request)
         .unwrap()
+        .nonblocking(actor)
         .perform()
         .await
         .unwrap();


### PR DESCRIPTION
There is a slight change in the builder pattern so that we could be able to use this crate dynamically both sync and async transactions for Curl rust.